### PR TITLE
Add ability to customize the rspec command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ With this configuration you can customize your rspec command as you please. Exam
 
 The default is `bundle exec rspec --color`.
 
+You can also customize it per project by adding the same configuration to your project's `.vscode/settings.json`.
+
 # Contributing
 
 Once you've made your great commits (include tests, please):

--- a/README.md
+++ b/README.md
@@ -36,7 +36,23 @@ Available commands:
 ]
 ```
 
-We going to enjoy!!
+Enjoy!
+
+## Settings
+
+### Custom command
+
+You might want to prefix the rspec command with something like docker or foreman.
+
+With this configuration you can customize your rspec command as you please. Example when using foreman:
+
+```json
+{
+  "vscode-run-rspec-file.custom-command": "foreman run bundle exec rspec --color",
+}
+```
+
+The default is `bundle exec rspec --color`.
 
 # Contributing
 

--- a/package.json
+++ b/package.json
@@ -95,7 +95,17 @@
                 "key": "cmd+y",
                 "when": "editorLangId == 'ruby'"
             }
-        ]
+        ],
+        "configuration": {
+          "title": "vscode-run-rspec-file",
+          "properties": {
+            "vscode-run-rspec-file.custom-command": {
+              "type": "string",
+              "default": "bundle exec rspec --color",
+              "description": "RSpec command to be used when running specs. Example: \"bundle exec rspec --color\""
+            }
+          }
+        }
     },
     "keywords": [
         "Ruby on Rails",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,8 @@ let terminals = {};
 let TERMINAL_NAME = "RSpec Run File";
 let lastExecuted = "";
 
+const SETTINGS_RSPEC_COMMAND_KEY = 'vscode-run-rspec-file.custom-command';
+
 function getAsRelativePath(): string {
   const rootFile: string = getFilename().replace(vscode.workspace.rootPath, "");
   const isApp: boolean = /^\/app\//.test(rootFile);
@@ -69,20 +71,19 @@ function execCommand(commandText: string) {
 }
 
 function bundleRspecAll() {
-  let commandText = `bundle exec rspec --color`;
-  execCommand(commandText);
+  execCommand(getRSpecCommand());
 }
 
 function bundleRspecFile() {
   let specFilename = getSpecFilePath();
-  let commandText = `bundle exec rspec --color ${specFilename}`;
+  let commandText = `${getRSpecCommand()} ${specFilename}`;
 
   execCommand(commandText);
 }
 
 function bundleRspecLine() {
   let specFilename = getSpecFilePath();
-  let commandText = `bundle exec rspec --color ${specFilename}:${getActiveLine()}`;
+  let commandText = `${getRSpecCommand()} ${specFilename}:${getActiveLine()}`;
   execCommand(commandText);
 }
 
@@ -92,6 +93,10 @@ function bundleRspecLastExecuted() {
   } else {
     vscode.window.showWarningMessage("RSpec : Not found last command executed");
   }
+}
+
+function getRSpecCommand(): string {
+  return vscode.workspace.getConfiguration().get(SETTINGS_RSPEC_COMMAND_KEY);
 }
 
 function clearTerminal() {


### PR DESCRIPTION
This is needed because people might want to run rspec using
foreman or docker like `foreman run bundle exec rspec --color`

Hi 👋 

Thanks for building this great extension. I was using it and I felt the need to customize the rspec command to prepend `foreman`. I've seen in plugins for other editors that they just let the user be able to customize the entire command so I did exactly that.

As the [updated readme](https://github.com/lucasprag/vscode-run-rspec-file/tree/rspec-command#custom-command) says the user can customize the rspec command using the vscode settings like:

```json
{
  "vscode-run-rspec-file.custom-command": "foreman run bundle exec rspec --color",
}
```

and the default is `bundle exec rspec --color`

Maybe in the future we can update the rspec command based on projects somehow.

Thanks for reviewing @thadeu =)