### PR TITLE
Match literal ".rb" in relative path

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,7 +28,7 @@ function getAsRelativePath(): string {
 
 function getFilePath(): string {
   return getAsRelativePath().replace(
-    /^(app\/)|(.rb)|(_spec.rb)|(spec\/)/gi,
+    /^(app\/)|(\.rb)|(_spec.rb)|(spec\/)/gi,
     ""
   );
 }


### PR DESCRIPTION
Previously, it would match any character followed by "rb".