### PR TITLE
Allow folder for controller specs to be configured 

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,16 @@ The default is `bundle exec rspec --color`.
 
 You can also customize it per project by adding the same configuration to your project's `.vscode/settings.json`.
 
+### Custom folder for controller specs
+
+You should now write specs for your controllers as request specs ([source](http://rspec.info/blog/2016/07/rspec-3-5-has-been-released/)). The default thus is to create controller specs at `spec/requests`, but this can be changed via:
+
+```json
+{
+  "vscode-run-rspec-file.controller-spec-directory": "controllers"
+}
+```
+
 # Contributing
 
 Once you've made your great commits (include tests, please):

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ You should now write specs for your controllers as request specs ([source](http:
 
 ```json
 {
-  "vscode-run-rspec-file.controller-spec-directory": "controllers"
+  "vscode-run-rspec-file.controller-spec-directory": "requests"
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
             "properties": {
                 "vscode-run-rspec-file.controller-spec-directory": {
                     "type": "string",
-                    "default": "requests",
+                    "default": "controllers",
                     "description": "The directory to place controller specs in."
                 },
                 "vscode-run-rspec-file.custom-command": {

--- a/package.json
+++ b/package.json
@@ -97,6 +97,11 @@
         "configuration": {
             "title": "vscode-run-rspec-file",
             "properties": {
+                "vscode-run-rspec-file.controller-spec-directory": {
+                    "type": "string",
+                    "default": "requests",
+                    "description": "The directory to place controller specs in."
+                },
                 "vscode-run-rspec-file.custom-command": {
                     "type": "string",
                     "default": "bundle exec rspec --color",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,11 +34,22 @@ function getAsRelativePath(): string {
   return ''
 }
 
+function getControllerSpecDirectory(): string {
+  return vscode.workspace.getConfiguration().get("vscode-run-rspec-file.controller-spec-directory");
+}
+
 function getFilePath(path?: string): string {
   let regex = /^(app\/)|(\.rb)|(_spec.rb)|(spec\/)/gi
   let value = (path || getAsRelativePath()).replace(regex, '')
 
-  return value
+  // Check if the input file is in the "controllers" directory.
+  if (value.startsWith("controllers/")) {
+    // Replace "controllers" with the configured directory for controller specs.
+    const controllerSpecDirectory = getControllerSpecDirectory();
+    value = value.replace("controllers", controllerSpecDirectory);
+  }
+
+  return value;
 }
 
 function getCurrentFilePath() {


### PR DESCRIPTION
Closes https://github.com/thadeu/vscode-run-rspec-file/issues/23

# What

This PR:

* Allow folder for controller specs to be configured.

# Why

As you may already know, controller specs are deprecated, from the [release notes](http://rspec.info/blog/2016/07/rspec-3-5-has-been-released/):

>For new Rails apps: we don't recommend adding the rails-controller-testing gem to your application. The official recommendation of the Rails team and the RSpec core team is to write request specs instead. Request specs allow you to focus on a single controller action, but unlike controller tests involve the router, the middleware stack, and both rack requests and responses. This adds realism to the test that you are writing, and helps avoid many of the issues that are common in controller specs. In Rails 5, request specs are significantly faster than either request or controller specs were in rails 4, thanks to the work by Eileen Uchitelle1 of the Rails Committer Team.

