### PR TITLE
Fix `customCommand`

### DIFF
--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -3,6 +3,7 @@ import get from 'lodash.get'
 
 import {
   SettingsType,
+  EXTENSION_NAME,
   SETTINGS_RSPEC_COMMAND_KEY,
   SETTINGS_RSPEC_FOLDER,
   SETTINGS_RSPEC_CONTROLLER_FOLDER,
@@ -58,7 +59,7 @@ export async function globalSettings(): Promise<SettingsType> {
 
     let config = vscode.workspace.getConfiguration()
 
-    let customCommand = config.get('custom-command') || config.get(SETTINGS_RSPEC_COMMAND_KEY)
+    let customCommand = config.inspect('custom-command').defaultValue || config.inspect(SETTINGS_RSPEC_COMMAND_KEY).defaultValue
 
     let folder = config.inspect('folder').defaultValue || config.inspect(SETTINGS_RSPEC_FOLDER).defaultValue
 

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -58,7 +58,7 @@ export async function globalSettings(): Promise<SettingsType> {
 
     let config = vscode.workspace.getConfiguration()
 
-    let customCommand = config.inspect('custom-command').defaultValue || config.inspect(SETTINGS_RSPEC_COMMAND_KEY).defaultValue
+    let customCommand = config.get('custom-command') || config.get(SETTINGS_RSPEC_COMMAND_KEY)
 
     let folder = config.inspect('folder').defaultValue || config.inspect(SETTINGS_RSPEC_FOLDER).defaultValue
 


### PR DESCRIPTION
Hello 👋

First of all, thanks for your extension 🙏 I use it every day an love it!

Since today's update I noticed my workspace custom command was not resolved properly anomore.
I think the problem is that the global setting for `customCommand` is always the default instead of the value set by the user.
Other options might be affected.