### PR TITLE
Handle absolute path when creating terminal

### DIFF
--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode'
 import get from 'lodash.get'
+import nodePath from 'path'
 
 import {
   SettingsType,
@@ -31,6 +32,12 @@ export function getWorkspace() {
     path: project.uri,
     name: project.name,
   }
+}
+
+export function createTerminal(name: string, path: string) {
+  let cwd = nodePath.isAbsolute(path) ? path : `/${path}`
+
+  return vscode.window.createTerminal({ name, cwd })
 }
 
 export function getByKeyOrAll(object, key) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,7 +3,14 @@ import get from 'lodash.get'
 
 import FileObject from './FileObject'
 
-import { getWorkspace, factorySettings, isMultipleWorkSpaces, getActiveLine, clearTerminal } from './Utils'
+import {
+  getWorkspace,
+  factorySettings,
+  isMultipleWorkSpaces,
+  getActiveLine,
+  clearTerminal,
+  createTerminal,
+} from './Utils'
 
 let terminals = {}
 let lastExecuted = ''
@@ -19,14 +26,14 @@ function getTerminal(): vscode.Terminal {
       return opened
     }
 
-    return vscode.window.createTerminal({ name, cwd: workspace.path })
+    return createTerminal(name, workspace.path)
   }
 
   if (get(terminals, name)) {
     return get(terminals, name)
   }
 
-  terminals[name] = vscode.window.createTerminal({ name, cwd: workspace.path })
+  terminals[name] = createTerminal(name, workspace.path)
   return get(terminals, name)
 }
 


### PR DESCRIPTION
On WSL (Ubuntu 22.04, more specifically) the terminal would fail to launch with a "The terminal process failed to launch". This is happening because the workspace path is being returned as a relative path, but `vscode.window.createTerminal` expects an absolute `cwd` parameter.

We solved that by simply appending a `/` at the front of the path in case it doesn't have one yet.

Closes #33