### PR TITLE
fix documentation url in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Facility run RSpec in the VSCode Terminal
 
 Version    | Documentation
 ---------- | -------------
-unreleased | https://github.com/thadeu/vscode-run-rspec-file/blob/main/README.md
+unreleased | https://github.com/thadeu/vscode-run-rspec-file/blob/master/README.md
 
 ## Features
 


### PR DESCRIPTION
The main branch did not exist, resulting in a 404 error.